### PR TITLE
Add `lampIndex` to `Lamp`

### DIFF
--- a/src/hue-interfaces.ts
+++ b/src/hue-interfaces.ts
@@ -383,6 +383,7 @@ export namespace States {
 }
 
 export interface Lamp {
+  lampIndex: number;
   state: States.LampState;
   type: string;
   name: string;

--- a/src/hue-node.ts
+++ b/src/hue-node.ts
@@ -585,7 +585,7 @@ export class Hue extends HueBridge {
   public async getLamps(): Promise<Lamp[]> {
     const url = this.buildLampCompositeURL();
     const { data } = await this.get(url);
-    return Object.keys(data).map(k => data[k]);
+    return Object.keys(data).map(k => ({...data[k], lampIndex: parseInt(k)}));
   }
 
   /**

--- a/src/hue-test-constants.ts
+++ b/src/hue-test-constants.ts
@@ -47,6 +47,7 @@ export const no_brightness: any = 1;
 
 export const lamp_response: any = {
   '1': {
+    lampIndex: 1,
     state: {
       on: true,
       bri: 144,
@@ -75,6 +76,7 @@ export const lamp_response: any = {
     }
   },
   '2': {
+    lampIndex: 2,
     state: {
       on: false,
       bri: 0,


### PR DESCRIPTION
fixes #7 

I think this approach works. The tests run and pass for me.

The `lampIndex` parameter is a number but the value we get from the Hue API is a string. I just added a conversion in the `getLamps()` function.

I'd guess this change should be backwards compatible, but I'm not certain on that. It was a quick and dirty change... :-)