### PR TITLE
Accept xy points in set color(s)

### DIFF
--- a/src/hue-node.ts
+++ b/src/hue-node.ts
@@ -316,14 +316,15 @@ export class Hue extends HueBridge {
    * the provided hex color.
    *
    * @param {number} lampIndex 1-based index of the Hue lamp to colorize.
-   * @param {string} color String representing a hexadecimal color value.
+   * @param {string | XYPoint} color String representing a hexadecimal color value (or an XYPoint)
    * @return {Promise<HueBridgeStateChangeResponse>} Promise representing the remote call
    */
   public async setColor(
     lampIndex: number,
-    color: string
+    color: string | XYPoint
   ): Promise<HueBridgeStateChangeResponse> {
-    const cieColor: XYPoint = this.colors.getCIEColor(color);
+    const cieColor: XYPoint =
+      color instanceof XYPoint ? color : this.colors.getCIEColor(color);
     const xyState: States.ColorState = this.buildXYState(cieColor);
 
     const { data } = await this.put(lampIndex, xyState);

--- a/src/hue-node.ts
+++ b/src/hue-node.ts
@@ -355,13 +355,14 @@ export class Hue extends HueBridge {
    * Sets all connected lamps to the approximate CIE x,y equivalent of
    * the provided hex color.
    *
-   * @param {string} color String representing a hexadecimal color value.
+   * @param {string | XYPoint} color String representing a hexadecimal color value (or an XYPoint)
    * @return {Promise<HueBridgeGroupActionResponse>} Promise representing the remote call
    */
   public async setAllColors(
-    color: string
+    color: string | XYPoint
   ): Promise<HueBridgeGroupActionResponse> {
-    const cieColor: XYPoint = this.colors.getCIEColor(color);
+    const cieColor: XYPoint =
+      color instanceof XYPoint ? color : this.colors.getCIEColor(color);
     const xyState: States.ColorState = this.buildXYState(cieColor);
 
     const { data } = await this.putGroupAction(0, xyState);


### PR DESCRIPTION
I had some weird issues with my lights immediately changing colour when I tried to read their xy values and set a very similar xy value. I dug into it a little and it looks like the issue is in the conversion of my xy values -> hex and then back to xy. As an alternative, I added a little tweak that accepts an `XYPoint` instances directly, and skips the conversion if so.

What do you think? Make sense to merge?

Tests still pass, but I haven't added any tests that explicitly check the XYPoint variant. It does work for me locally, but that's not saying much! :-)