### PR TITLE
Update hue unpnp URL

### DIFF
--- a/src/hue-node.spec.ts
+++ b/src/hue-node.spec.ts
@@ -259,7 +259,7 @@ test.serial('search', async t => {
     { id: '785d973935391ad0', internalipaddress: '192.168.x.x' }
   ];
 
-  moxios.stubRequest(`https://www.meethue.com/api/nupnp`, {
+  moxios.stubRequest(`https://discovery.meethue.com/`, {
     status: 200,
     method: 'GET',
     response: nupnpResponse

--- a/src/hue-node.ts
+++ b/src/hue-node.ts
@@ -22,7 +22,7 @@ const longFlashState: States.AlertState = { alert: 'lselect' };
 const colorLoopEffect: States.EffectState = { effect: 'colorloop' };
 const noEffect: States.EffectState = { effect: 'none' };
 const _colors = new HueColors();
-const nupnpEndpoint: string = `https://www.meethue.com/api/nupnp`;
+const nupnpEndpoint: string = `https://discovery.meethue.com/`;
 const _http = axios.default.create({
   timeout: 5000
 });


### PR DESCRIPTION
Pure guess work, but it seems that Hue changed their URL and the old one returns 404, which breaks the code. This change works for me locally, but I'm not really clear why or how, so treat this PR with caution would be my advice! :-)